### PR TITLE
Call plugin finally function when build fails as well.

### DIFF
--- a/SmvLibrary/Utility.cs
+++ b/SmvLibrary/Utility.cs
@@ -651,6 +651,7 @@ namespace SmvLibrary
                         if (!fromWorker)
                         {
                             scheduler.Dispose();
+                            plugin.Finally(true);
                             Log.LogFatalError(String.Format("Action: {0}, failed.", name));
                         }
                     }

--- a/SmvLineCounter/SmvLineCounter.cs
+++ b/SmvLineCounter/SmvLineCounter.cs
@@ -70,5 +70,10 @@ namespace SmvLineCounter
         {
             throw new NotImplementedException();
         }
+
+        public void Finally(bool failures)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/StaticModuleVerifier/Program.cs
+++ b/StaticModuleVerifier/Program.cs
@@ -317,6 +317,10 @@ namespace SmvSkeleton
 
                 List<SMVActionResult> buildActionsResult = Utility.ExecuteActions(Utility.GetRootActions(smvConfig.Build));
                 buildResult = Utility.IsExecuteActionsSuccessful(buildActionsResult);
+                if (Utility.plugin != null && buildResult == false)
+                {
+                    Utility.plugin.Finally(true);
+                }
 
                 if (Utility.plugin != null)
                 {


### PR DESCRIPTION
Some use cases (like generating DVLs for SDV when the build fails) require the Finally function to be called even if SMV fails at the build step.  This adds that functionality (and adds a Finally stub to SmvLineCounter.)