### PR TITLE
Change slamcl_writer + debug logic

### DIFF
--- a/SmvInterceptor/SmvInterceptor.cs
+++ b/SmvInterceptor/SmvInterceptor.cs
@@ -396,7 +396,7 @@ namespace SmvInterceptor
 
                 p.WaitForExit();
 
-                WriteCallLog("EXIT: " + p.StartInfo.FileName + ". Exit code: " + p.ExitCode);
+                WriteCallLog("EXIT: " + p.StartInfo.FileName + ", return code: " + p.ExitCode);
                 exitCode = p.ExitCode;
 
             }

--- a/SmvInterceptor/SmvInterceptor.cs
+++ b/SmvInterceptor/SmvInterceptor.cs
@@ -705,12 +705,12 @@ namespace SmvInterceptor
 
         private static void PrintEnvSpew(string[] args, XmlNode settingsNode)
         {
-            debugSpew = RetrieveBool("debug_spew", settingsNode);
+            debugSpew = !String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SMV_DEBUG_MODE"));
             if (debugSpew)
             {
-                Console.WriteLine("INCLUDE = {0}", Environment.GetEnvironmentVariable("INCLUDE"));
-                Console.WriteLine("LIB = {0}", Environment.GetEnvironmentVariable("LIB"));
-                Console.WriteLine("PATH = {0}", Environment.GetEnvironmentVariable("PATH"));
+                WriteInterceptorLog(String.Format("INCLUDE = {0}", Environment.GetEnvironmentVariable("INCLUDE")));
+                WriteInterceptorLog(String.Format("LIB = {0}", Environment.GetEnvironmentVariable("LIB")));
+                WriteInterceptorLog(String.Format("PATH = {0}", Environment.GetEnvironmentVariable("PATH")));
                 foreach (string arg in args)
                 {
                     if (arg[0] != '@')
@@ -719,20 +719,20 @@ namespace SmvInterceptor
                     try
                     {
                         string rsp = arg.Substring(1);
-                        Console.WriteLine("Contents of response file ({0}):", rsp);
+                        WriteInterceptorLog(String.Format("Contents of response file ({0}):", rsp));
                         using (var reader = new StreamReader(new FileStream(rsp, FileMode.Open, FileAccess.Read)))
                         {
-                            Console.Write(reader.ReadToEnd());
+                            WriteInterceptorLog(reader.ReadToEnd());
                         }
                     }
                     catch (Exception)
                     {
-                        Console.WriteLine("Error while reading .rsp file");
+                        WriteInterceptorLog("Error while reading .rsp file");
                     }
                 }
                 foreach (XmlAttribute setting in settingsNode.Attributes)
                 {
-                    Console.WriteLine("Setting::" + setting.Name + " = " + setting.Value);
+                    WriteInterceptorLog("Setting::" + setting.Name + " = " + setting.Value);
                 }
             }
         }

--- a/SmvInterceptor/SmvInterceptor.cs
+++ b/SmvInterceptor/SmvInterceptor.cs
@@ -186,7 +186,7 @@ namespace SmvInterceptor
             {
                 smvOutDir = Environment.CurrentDirectory;
             }
-            File.AppendAllText(Path.Combine(smvOutDir, "smv-callDebug.log"), "[smvInterceptor] " + toLog + Environment.NewLine);
+            File.AppendAllText(Path.Combine(smvOutDir, "smvexecute-Interceptor.log"), "[smvInterceptor] " + toLog + Environment.NewLine);
         }
 
         /// <summary>

--- a/SmvInterceptor/SmvInterceptor.cs
+++ b/SmvInterceptor/SmvInterceptor.cs
@@ -178,14 +178,25 @@ namespace SmvInterceptor
             }
         }
 
-
-        static void WriteCallLog(string toLog)
+        /// <summary>
+        /// Log debug information to %SMV_OUTPUT_DIR%\smvexecute-Interceptor.log if in debug mode.
+        /// Prefix any strings with [smvInterceptor]
+        /// </summary>
+        /// <param name="toLog">The string to be logged.</param>
+        static void WriteInterceptorLog(string toLog)
         {
+            // Only log if /debug enabled
+            if (String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SMV_DEBUG_MODE")))
+            {
+                return;
+            }
+
             string smvOutDir = Environment.GetEnvironmentVariable("SMV_OUTPUT_DIR");
             if (string.IsNullOrWhiteSpace(smvOutDir))
             {
                 smvOutDir = Environment.CurrentDirectory;
             }
+
             File.AppendAllText(Path.Combine(smvOutDir, "smvexecute-Interceptor.log"), "[smvInterceptor] " + toLog + Environment.NewLine);
         }
 
@@ -387,7 +398,7 @@ namespace SmvInterceptor
 
             try
             {
-                WriteCallLog("LAUNCH: " + p.StartInfo.FileName + " " + p.StartInfo.Arguments);
+                WriteInterceptorLog("LAUNCH: " + p.StartInfo.FileName + " " + p.StartInfo.Arguments);
                 p.Start();
                 p.PriorityClass = priority;
 
@@ -396,7 +407,7 @@ namespace SmvInterceptor
 
                 p.WaitForExit();
 
-                WriteCallLog("EXIT: " + p.StartInfo.FileName + ". Exit code: " + p.ExitCode);
+                WriteInterceptorLog("EXIT: " + p.StartInfo.FileName + ". Exit code: " + p.ExitCode);
                 exitCode = p.ExitCode;
 
             }
@@ -695,8 +706,6 @@ namespace SmvInterceptor
         private static void PrintEnvSpew(string[] args, XmlNode settingsNode)
         {
             debugSpew = RetrieveBool("debug_spew", settingsNode);
-
-            // Spew
             if (debugSpew)
             {
                 Console.WriteLine("INCLUDE = {0}", Environment.GetEnvironmentVariable("INCLUDE"));

--- a/SmvInterceptor/SmvInterceptor.cs
+++ b/SmvInterceptor/SmvInterceptor.cs
@@ -178,6 +178,17 @@ namespace SmvInterceptor
             }
         }
 
+
+        static void WriteCallLog(string toLog)
+        {
+            string smvOutDir = Environment.GetEnvironmentVariable("SMV_OUTPUT_DIR");
+            if (string.IsNullOrWhiteSpace(smvOutDir))
+            {
+                smvOutDir = Environment.CurrentDirectory;
+            }
+            File.AppendAllText(Path.Combine(smvOutDir, "smv-callDebug.log"), "[smvInterceptor] " + toLog + Environment.NewLine);
+        }
+
         /// <summary>
         /// Calculates the executable to be used and processes the rules of adding/stripping arguments
         /// </summary>
@@ -376,6 +387,7 @@ namespace SmvInterceptor
 
             try
             {
+                WriteCallLog("LAUNCH: " + p.StartInfo.FileName + " " + p.StartInfo.Arguments);
                 p.Start();
                 p.PriorityClass = priority;
 
@@ -384,6 +396,7 @@ namespace SmvInterceptor
 
                 p.WaitForExit();
 
+                WriteCallLog("EXIT: " + p.StartInfo.FileName + ", return code: " + p.ExitCode);
                 exitCode = p.ExitCode;
 
             }

--- a/SmvInterceptor/SmvInterceptor.cs
+++ b/SmvInterceptor/SmvInterceptor.cs
@@ -192,6 +192,7 @@ namespace SmvInterceptor
             }
 
             string smvOutDir = Environment.GetEnvironmentVariable("SMV_OUTPUT_DIR");
+
             if (string.IsNullOrWhiteSpace(smvOutDir))
             {
                 smvOutDir = Environment.CurrentDirectory;

--- a/SmvInterceptor/SmvInterceptor.cs
+++ b/SmvInterceptor/SmvInterceptor.cs
@@ -705,7 +705,10 @@ namespace SmvInterceptor
 
         private static void PrintEnvSpew(string[] args, XmlNode settingsNode)
         {
-            debugSpew = !String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SMV_DEBUG_MODE"));
+            // Set debugSpew if set in interceptor XML or environment via /debug flag + plugin settings
+            debugSpew = (RetrieveBool("debug_spew", settingsNode) ||
+                         !String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SMV_DEBUG_MODE")));
+
             if (debugSpew)
             {
                 WriteInterceptorLog(String.Format("INCLUDE = {0}", Environment.GetEnvironmentVariable("INCLUDE")));

--- a/SmvInterceptor/SmvInterceptor.cs
+++ b/SmvInterceptor/SmvInterceptor.cs
@@ -396,7 +396,7 @@ namespace SmvInterceptor
 
                 p.WaitForExit();
 
-                WriteCallLog("EXIT: " + p.StartInfo.FileName + ", return code: " + p.ExitCode);
+                WriteCallLog("EXIT: " + p.StartInfo.FileName + ". Exit code: " + p.ExitCode);
                 exitCode = p.ExitCode;
 
             }

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -278,7 +278,7 @@ namespace SmvInterceptorWrapper
 
                 p = System.Diagnostics.Process.Start(psi);
                 File.WriteAllText(outDir + "\\smvlink1.log", p.StandardOutput.ReadToEnd());
-                File.AppendAllText(outDir + "\\smvlink2.log", p.StandardError.ReadToEnd());
+                File.AppendAllText(outDir + "\\smvlink1.log", p.StandardError.ReadToEnd());
 
                 p.WaitForExit();
 
@@ -374,8 +374,8 @@ namespace SmvInterceptorWrapper
 
                             WriteCallLog("EXIT: slamlink.exe.  Exit code: " + slamLinkProcess.ExitCode);
 
-                            File.WriteAllText(outDir + "\\smvlink.log", slamLinkProcess.StandardOutput.ReadToEnd());
-                            File.AppendAllText(outDir + "\\smvlink.log", slamLinkProcess.StandardError.ReadToEnd());
+                            File.AppendAllText(outDir + "\\smvlink3.log", slamLinkProcess.StandardOutput.ReadToEnd());
+                            File.AppendAllText(outDir + "\\smvlink3.log", slamLinkProcess.StandardError.ReadToEnd());
 
                             if (slamLinkProcess.ExitCode != 0) return slamLinkProcess.ExitCode;
                         }

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -260,30 +260,32 @@ namespace SmvInterceptorWrapper
                 ProcessStartInfo psi;
                 Process p;
 
+                foreach (string file in rawcfgfFiles)
+                {
+                    psi = new ProcessStartInfo(Environment.ExpandEnvironmentVariables("slamcl_writer.exe"), file + " " + (file + ".obj") );
+                    psi.RedirectStandardError = true;
+                    psi.RedirectStandardOutput = true;
+                    psi.UseShellExecute = false;
+                    psi.WorkingDirectory = outDir;
 
-                psi = new ProcessStartInfo(Environment.ExpandEnvironmentVariables("slamcl_writer.exe"), "--smv *");
-                psi.RedirectStandardError = true;
-                psi.RedirectStandardOutput = true;
-                psi.UseShellExecute = false;
-                psi.WorkingDirectory = outDir;
+                    WriteCallLog("LAUNCH: link: " + psi.FileName + " " + psi.Arguments);
+                    WriteCallLog("PATH: " + Environment.ExpandEnvironmentVariables("%PATH%"));
+                    WriteCallLog("SDV: " + Environment.ExpandEnvironmentVariables("%sdv%"));
+                    WriteCallLog("SMV: " + Environment.ExpandEnvironmentVariables("%smv%"));
+                    WriteCallLog("BE: " + Environment.ExpandEnvironmentVariables("%be%"));
+                    WriteCallLog("SMV_OUTPUT_DIR: " + Environment.ExpandEnvironmentVariables("%SMV_OUTPUT_DIR%"));
 
-                WriteCallLog("LAUNCH: link: " + psi.FileName + " " + psi.Arguments);
-                WriteCallLog("PATH: " + Environment.ExpandEnvironmentVariables("%PATH%"));
-                WriteCallLog("SDV: " + Environment.ExpandEnvironmentVariables("%sdv%"));
-                WriteCallLog("SMV: " + Environment.ExpandEnvironmentVariables("%smv%"));
-                WriteCallLog("BE: " + Environment.ExpandEnvironmentVariables("%be%"));
-                WriteCallLog("SMV_OUTPUT_DIR: " + Environment.ExpandEnvironmentVariables("%SMV_OUTPUT_DIR%"));
+                    //Console.WriteLine("iwrap: link.exe --> " + psi.FileName + " " + psi.Arguments);
 
-                //Console.WriteLine("iwrap: link.exe --> " + psi.FileName + " " + psi.Arguments);
+                    p = System.Diagnostics.Process.Start(psi);
+                    File.AppendAllText(outDir + "\\smvlink1.log", p.StandardOutput.ReadToEnd());
+                    File.AppendAllText(outDir + "\\smvlink1.log", p.StandardError.ReadToEnd());
 
-                p = System.Diagnostics.Process.Start(psi);
-                File.WriteAllText(outDir + "\\smvlink1.log", p.StandardOutput.ReadToEnd());
-                File.AppendAllText(outDir + "\\smvlink1.log", p.StandardError.ReadToEnd());
+                    p.WaitForExit();
 
-                p.WaitForExit();
-
-                WriteCallLog("EXIT: slamcl_writer.exe.  Exit code: " + p.ExitCode);
-                if (p.ExitCode != 0) return p.ExitCode;
+                    WriteCallLog("EXIT: slamcl_writer.exe.  Exit code: " + p.ExitCode);
+                    if (p.ExitCode != 0) return p.ExitCode;
+                }
 
                 files = files.Select(x => x + ".rawcfgf.obj").ToArray();
                 

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -350,7 +350,7 @@ namespace SmvInterceptorWrapper
                     if (l.Equals(outDir)) continue;
                     try
                     {
-                        WriteCallLog("DEBUG: Processing lib " + l);
+                        WriteCallLog("DEBUG: Processing libs in " + l);
                         string[] liFilesInLibDir = Directory.GetFiles(l, "slam.li");
 
                         foreach (string liFile in liFilesInLibDir)
@@ -374,10 +374,12 @@ namespace SmvInterceptorWrapper
 
                             slamLinkProcess = System.Diagnostics.Process.Start(psi);
 
-                            WriteCallLog("EXIT: slamlink.exe.  Exit code: " + slamLinkProcess.ExitCode);
 
                             File.AppendAllText(outDir + "\\smvlink3.log", slamLinkProcess.StandardOutput.ReadToEnd());
                             File.AppendAllText(outDir + "\\smvlink3.log", slamLinkProcess.StandardError.ReadToEnd());
+
+                            slamLinkProcess.WaitForExit();
+                            WriteCallLog("EXIT: slamlink.exe.  Exit code: " + slamLinkProcess.ExitCode);
 
                             if (slamLinkProcess.ExitCode != 0) return slamLinkProcess.ExitCode;
                         }

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -202,7 +202,9 @@ namespace SmvInterceptorWrapper
                             p = System.Diagnostics.Process.Start(psi);
                             File.WriteAllText(cfgOutputPath, p.StandardOutput.ReadToEnd());
                             File.WriteAllText(cfgErrorPath, p.StandardError.ReadToEnd());
-                            p.WaitForExit();
+
+                            // Allow 5 minutes for each, then continue; don't hang indefinitely on debug
+                            p.WaitForExit(5 * 60 * 1000);
                         }
                     }
                 }

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -13,6 +13,9 @@ namespace SmvInterceptorWrapper
 {
     class Program
     {
+
+        static bool debugMode = false;
+
         static int Main(string[] args)
         {
             // Get the output dir from the Environment variable set by SMV
@@ -27,6 +30,11 @@ namespace SmvInterceptorWrapper
             StringBuilder smvclLogContents = new StringBuilder();
             List<string> iargs = args.Where(x => !x.Contains("/iwrap:") && !x.Contains(".rsp") && !x.Contains("/plugin:")).ToList();
 
+            // Below code is non-functional until additional changes
+            // if (args.Contains("--debug-compiler"))
+            // {
+            //     debugMode = true;
+            // }
 
             #region cl.exe            
             if (args.Contains("/iwrap:cl.exe"))
@@ -163,14 +171,17 @@ namespace SmvInterceptorWrapper
                 
                 WriteCallLog("EXIT: CL.exe.  Exit code: " + p.ExitCode);
 
-                // Run with /P to get preprocessed output for debugging
-                psi = new ProcessStartInfo(System.IO.Path.GetFullPath(Environment.ExpandEnvironmentVariables("%SMV_ANALYSIS_COMPILER%")), Environment.ExpandEnvironmentVariables(rspContentsDebug));
-                psi.RedirectStandardError = true;
-                psi.RedirectStandardOutput = true;
-                psi.UseShellExecute = false;
-                p = System.Diagnostics.Process.Start(psi);
+                if (debugMode)
+                {
+                    // Run with /P to get preprocessed output for debugging
+                    psi = new ProcessStartInfo(System.IO.Path.GetFullPath(Environment.ExpandEnvironmentVariables("%SMV_ANALYSIS_COMPILER%")), Environment.ExpandEnvironmentVariables(rspContentsDebug));
+                    psi.RedirectStandardError = true;
+                    psi.RedirectStandardOutput = true;
+                    psi.UseShellExecute = false;
+                    p = System.Diagnostics.Process.Start(psi);
 
-                p.WaitForExit();
+                    p.WaitForExit();
+                }
 
                 /*
                 // Call ESPSMVPRINT_AUX
@@ -409,12 +420,13 @@ namespace SmvInterceptorWrapper
 
         static void WriteCallLog(string toLog)
         {
+            if (!debugMode) return;
             string smvOutDir = Environment.GetEnvironmentVariable("SMV_OUTPUT_DIR");
             if (string.IsNullOrWhiteSpace(smvOutDir))
             {
                 smvOutDir = Environment.CurrentDirectory;
             }
-            File.AppendAllText(Path.Combine(smvOutDir, "smv-callDebug.log"), "[smvInterceptorWrapper] " + toLog + Environment.NewLine);
+            File.AppendAllText(Path.Combine(smvOutDir, "smvexecute-Interceptor.log"), "[smvInterceptorWrapper] " + toLog + Environment.NewLine);
         }
 
         /// <summary>

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.IO;
 using System.Globalization;
+using System.Collections;
 
 namespace SmvInterceptorWrapper
 {
@@ -91,14 +92,23 @@ namespace SmvInterceptorWrapper
 
                 rspFileContent = rspContents;
 
+                string rspContentsDebug = Environment.ExpandEnvironmentVariables(" /nologo /w /Y- /D_PREFAST_ /errorReport:none" + " " + string.Join(" ", iargs)) + " " + rspContents + " /P";
+                rspContentsDebug = rspContentsDebug.Replace("/analyze:only", " ");
+                rspContentsDebug = rspContentsDebug.Replace("/analyze:autolog-", " ");
+
                 rspContents = Environment.ExpandEnvironmentVariables(" /nologo /w /Y- /analyze:only /analyze:plugin \"" + plugin +
                               "\" /errorReport:none" + " " + string.Join(" ", iargs)) + " " + rspContents;
+
+
 
                 // Persist the RSP file 
                 // Remove file names (*.c) from the content
                 Regex fileNameRegex1 = new Regex(@"([\s]+[\w\.-\\]+\.c\b)", RegexOptions.IgnoreCase|RegexOptions.Multiline);
                 Regex fileNameRegex2 = new Regex(@"([\s]+[\w\.-\\]+\.(cpp|cxx))", RegexOptions.IgnoreCase|RegexOptions.Multiline);
+
+                List<string> fileNames = new List<string>();
                 int count = 0;
+
                 foreach (Match m in fileNameRegex1.Matches(rspContents))
                 {
                     count++;
@@ -117,9 +127,25 @@ namespace SmvInterceptorWrapper
                 // if no files are left (only .src etc. was given) then just return. nothing to do
                 if(count == 0) { return 0; }
 
+
+                // TODO: Make this based on /debug flag
+
+                // Re-run with /P to get preprocessed output as well
+
+                ProcessStartInfo psi = new ProcessStartInfo(System.IO.Path.GetFullPath(Environment.ExpandEnvironmentVariables("%SMV_ANALYSIS_COMPILER%")), Environment.ExpandEnvironmentVariables(rspContentsDebug));
+                psi.RedirectStandardError = true;
+                psi.RedirectStandardOutput = true;
+                psi.UseShellExecute = false;
+                Process p = System.Diagnostics.Process.Start(psi);
+
+                smvclLogContents.Append(p.StandardOutput.ReadToEnd());
+                smvclLogContents.Append(p.StandardError.ReadToEnd());
+                File.WriteAllText(smvclLogPath, smvclLogContents.ToString());
+                p.WaitForExit();
+
                 // call CL.exe
                 //Console.WriteLine("Using analysis compiler: " + Environment.ExpandEnvironmentVariables("%SMV_ANALYSIS_COMPILER%"));
-                ProcessStartInfo psi = new ProcessStartInfo(System.IO.Path.GetFullPath(Environment.ExpandEnvironmentVariables("%SMV_ANALYSIS_COMPILER%")), Environment.ExpandEnvironmentVariables(rspContents));
+                psi = new ProcessStartInfo(System.IO.Path.GetFullPath(Environment.ExpandEnvironmentVariables("%SMV_ANALYSIS_COMPILER%")), Environment.ExpandEnvironmentVariables(rspContents));
                 psi.RedirectStandardError = true;
                 psi.RedirectStandardOutput = true;
                 psi.UseShellExecute = false;
@@ -135,25 +161,54 @@ namespace SmvInterceptorWrapper
 
                 //Console.WriteLine("iwrap: cl.exe --> " + psi.FileName + " " + psi.Arguments);
 
-                WriteCallLog("LAUNCH: iwrap: cl.exe-- > " + psi.FileName + " " + psi.Arguments);
+                WriteCallLog("LAUNCH: iwrap: " + psi.FileName + " " + psi.Arguments);
                 WriteCallLog("PATH: " + Environment.ExpandEnvironmentVariables("%PATH%"));
                 WriteCallLog("SDV: " + Environment.ExpandEnvironmentVariables("%sdv%"));
                 WriteCallLog("SMV: " + Environment.ExpandEnvironmentVariables("%smv%"));
                 WriteCallLog("BE: " + Environment.ExpandEnvironmentVariables("%be%"));
                 WriteCallLog("SMV_OUTPUT_DIR: " + Environment.ExpandEnvironmentVariables("%SMV_OUTPUT_DIR%"));
-                WriteCallLog("STATIC_DRIVER_VERIFIER: " + Environment.ExpandEnvironmentVariables("%STATIC_DRIVER_VERIFIER%"));
-                WriteCallLog("SDVFROMGIT: " + Environment.ExpandEnvironmentVariables("%SDVFROMGIT%"));
-                WriteCallLog("SETERROR_64: " + Environment.ExpandEnvironmentVariables("%SETERROR_64%"));
+                
+                string environmentVars = "";
+                environmentVars += "esp.cfgpersist.persistfile=";
+                environmentVars += (smvOutDir + "\\$SOURCEFILE.rawcfgf");
+                environmentVars += "  ";
+                environmentVars += "Esp.CfgPersist.ExpandLocalStaticInitializer=1";
+                environmentVars += "  ";
+                environmentVars += "ESP.BplFilesDir=";
+                environmentVars += smvOutDir;
+                WriteCallLog("Process-specific environment variables: " + environmentVars);
 
-                Process p = System.Diagnostics.Process.Start(psi);
+                p = System.Diagnostics.Process.Start(psi);
 
                 smvclLogContents.Append(p.StandardOutput.ReadToEnd());
                 smvclLogContents.Append(p.StandardError.ReadToEnd());
                 File.WriteAllText(smvclLogPath, smvclLogContents.ToString());
                 p.WaitForExit();
-
+                
                 WriteCallLog("EXIT: CL.exe.  Exit code: " + p.ExitCode);
 
+                /*
+                // Call ESPSMVPRINT_AUX
+                foreach (FileInfo f in new DirectoryInfo(smvOutDir).GetFiles())
+                {
+                    if (f.Name.Contains(".rawcfgf"))
+                    {
+                        string espSmvPrintPath = Path.Combine(Environment.ExpandEnvironmentVariables("%SDV%"), "bin", "engine", "espsmvprintaux.exe");
+                        psi = new ProcessStartInfo(espSmvPrintPath, f.FullName);
+                        psi.RedirectStandardOutput = true;
+                        psi.RedirectStandardError = true;
+                        psi.UseShellExecute = false;
+
+                        string cfgOutputPath = f.FullName.Replace(".rawcfgf", ".txt");
+                        string cfgErrorPath = f.FullName.Replace(".rawcfgf", ".err");
+
+                        p = System.Diagnostics.Process.Start(psi);
+                        File.WriteAllText(cfgOutputPath, p.StandardOutput.ReadToEnd());
+                        File.WriteAllText(cfgErrorPath, p.StandardError.ReadToEnd());
+                        p.WaitForExit();
+                    }
+                }*/
+                
                 return p.ExitCode;
             }
             #endregion
@@ -212,22 +267,18 @@ namespace SmvInterceptorWrapper
                 psi.UseShellExecute = false;
                 psi.WorkingDirectory = outDir;
 
-                WriteCallLog("LAUNCH: link: slamcl_writer.exe-- > " + psi.FileName + " " + psi.Arguments);
+                WriteCallLog("LAUNCH: link: " + psi.FileName + " " + psi.Arguments);
                 WriteCallLog("PATH: " + Environment.ExpandEnvironmentVariables("%PATH%"));
                 WriteCallLog("SDV: " + Environment.ExpandEnvironmentVariables("%sdv%"));
                 WriteCallLog("SMV: " + Environment.ExpandEnvironmentVariables("%smv%"));
                 WriteCallLog("BE: " + Environment.ExpandEnvironmentVariables("%be%"));
                 WriteCallLog("SMV_OUTPUT_DIR: " + Environment.ExpandEnvironmentVariables("%SMV_OUTPUT_DIR%"));
-                WriteCallLog("STATIC_DRIVER_VERIFIER: " + Environment.ExpandEnvironmentVariables("%STATIC_DRIVER_VERIFIER%"));
-                WriteCallLog("SDVFROMGIT: " + Environment.ExpandEnvironmentVariables("%SDVFROMGIT%"));
-                WriteCallLog("SETERROR_64: " + Environment.ExpandEnvironmentVariables("%SETERROR_64%"));
-
 
                 //Console.WriteLine("iwrap: link.exe --> " + psi.FileName + " " + psi.Arguments);
 
                 p = System.Diagnostics.Process.Start(psi);
                 File.WriteAllText(outDir + "\\smvlink1.log", p.StandardOutput.ReadToEnd());
-                File.AppendAllText(outDir + "\\smvlink1.log", p.StandardError.ReadToEnd());
+                File.AppendAllText(outDir + "\\smvlink2.log", p.StandardError.ReadToEnd());
 
                 p.WaitForExit();
 
@@ -253,7 +304,7 @@ namespace SmvInterceptorWrapper
                     psi.Arguments = " --lib " + string.Join(" ", files);
 
                     WriteCallLog("DEBUG: about to run slamlink on " + files.Length + " .rawcfgf.obj files");
-                    WriteCallLog("LAUNCH: iwrap: slamlink.exe-- > " + psi.FileName + " " + psi.Arguments);
+                    WriteCallLog("LAUNCH: iwrap: " + psi.FileName + " " + psi.Arguments);
 
                     //Console.WriteLine("iwrap: link.exe --> " + psi.FileName + " " + psi.Arguments);
                     Process slamLinkProcess = System.Diagnostics.Process.Start(psi);
@@ -317,7 +368,7 @@ namespace SmvInterceptorWrapper
                             psi.Arguments = " --lib slamorig.obj slamlib.obj /out:slamout.obj";
 
                             WriteCallLog("DEBUG: about to run slamlink on " + liFile);
-                            WriteCallLog("LAUNCH: iwrap: slamlink.exe-- > " + psi.FileName + " " + psi.Arguments);
+                            WriteCallLog("LAUNCH: iwrap: " + psi.FileName + " " + psi.Arguments);
 
                             slamLinkProcess = System.Diagnostics.Process.Start(psi);
 
@@ -380,7 +431,7 @@ namespace SmvInterceptorWrapper
             {
                 smvOutDir = Environment.CurrentDirectory;
             }
-            File.AppendAllText(Path.Combine(smvOutDir, "smv-callDebug.log"), "[iwrap] " + toLog + Environment.NewLine);
+            File.AppendAllText(Path.Combine(smvOutDir, "smv-callDebug.log"), "[smvInterceptorWrapper] " + toLog + Environment.NewLine);
         }
 
         /// <summary>

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -30,11 +30,10 @@ namespace SmvInterceptorWrapper
             StringBuilder smvclLogContents = new StringBuilder();
             List<string> iargs = args.Where(x => !x.Contains("/iwrap:") && !x.Contains(".rsp") && !x.Contains("/plugin:")).ToList();
 
-            // Below code is non-functional until additional changes
-            // if (args.Contains("--debug-compiler"))
-            // {
-            //     debugMode = true;
-            // }
+            if (Environment.GetEnvironmentVariable("SMV_DEBUG_MODE") != null)
+            {
+                debugMode = true;
+            }
 
             #region cl.exe            
             if (args.Contains("/iwrap:cl.exe"))

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.IO;
 using System.Globalization;
+using System.Runtime.Remoting.Metadata.W3cXsd2001;
 
 namespace SmvInterceptorWrapper
 {
@@ -14,6 +15,7 @@ namespace SmvInterceptorWrapper
     {
 
         static bool debugMode = false;
+        const int DEFAULT_DEBUG_TIMEOUT = (5 * 60 * 1000);
 
         static int Main(string[] args)
         {
@@ -179,8 +181,21 @@ namespace SmvInterceptorWrapper
                     psi.UseShellExecute = false;
                     p = System.Diagnostics.Process.Start(psi);
 
+                    // Get debug timeout from environment variable set in XML or command line
+                    int debugTimeout = 0;
+
+                    try
+                    {
+                        debugTimeout = int.Parse(Environment.GetEnvironmentVariable("SMV_DEBUG_TIMEOUT"));
+                    }
+                    catch (Exception)
+                    {
+                        // If there was any trouble, just set it to 5 minutes
+                        debugTimeout = DEFAULT_DEBUG_TIMEOUT;
+                    }
+
                     // Allow 5 minutes for this, then continue; don't hang indefinitely on debug
-                    p.WaitForExit(5 * 60 * 1000);
+                    p.WaitForExit(debugTimeout);
 
                     // Call ESPSMVPRINT_AUX
                     foreach (FileInfo f in new DirectoryInfo(smvOutDir).GetFiles())

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -262,7 +262,7 @@ namespace SmvInterceptorWrapper
 
                 foreach (string file in rawcfgfFiles)
                 {
-                    psi = new ProcessStartInfo(Environment.ExpandEnvironmentVariables("slamcl_writer.exe"), file + " " + (file + ".obj") );
+                    psi = new ProcessStartInfo(Environment.ExpandEnvironmentVariables("slamcl_writer.exe"), "--smv " + file + " " + (file + ".obj") );
                     psi.RedirectStandardError = true;
                     psi.RedirectStandardOutput = true;
                     psi.UseShellExecute = false;

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -149,16 +149,17 @@ namespace SmvInterceptorWrapper
                 
                 WriteInterceptorLog("LAUNCH: iwrap: " + psi.FileName + " " + psi.Arguments);
                 WriteInterceptorLog("PATH: " + Environment.ExpandEnvironmentVariables("%PATH%"));
+
+                StringBuilder sb = new StringBuilder();
+                sb.Append("esp.cfgpersist.persistfile=");
+                sb.Append((smvOutDir + "\\$SOURCEFILE.rawcfgf"));
+                sb.Append("  ");
+                sb.Append("Esp.CfgPersist.ExpandLocalStaticInitializer=1");
+                sb.Append("  ");
+                sb.Append("ESP.BplFilesDir=");
+                sb.Append(smvOutDir);
                 
-                string environmentVars = "";
-                environmentVars += "esp.cfgpersist.persistfile=";
-                environmentVars += (smvOutDir + "\\$SOURCEFILE.rawcfgf");
-                environmentVars += "  ";
-                environmentVars += "Esp.CfgPersist.ExpandLocalStaticInitializer=1";
-                environmentVars += "  ";
-                environmentVars += "ESP.BplFilesDir=";
-                environmentVars += smvOutDir;
-                WriteInterceptorLog("Process-specific environment variables: " + environmentVars);
+                WriteInterceptorLog("Process-specific environment variables: " + sb.ToString());
 
                 Process p = System.Diagnostics.Process.Start(psi);
 
@@ -430,9 +431,13 @@ namespace SmvInterceptorWrapper
         /// <param name="toLog">The string to be logged.</param>
         static void WriteInterceptorLog(string toLog)
         {
-            if (!debugMode) return;
+            if (!debugMode)
+            {
+                return;
+            }
 
             string smvOutDir = Environment.GetEnvironmentVariable("SMV_OUTPUT_DIR");
+
             if (string.IsNullOrWhiteSpace(smvOutDir))
             {
                 smvOutDir = Environment.CurrentDirectory;

--- a/StaticModuleVerifier/Program.cs
+++ b/StaticModuleVerifier/Program.cs
@@ -145,6 +145,7 @@ namespace SmvSkeleton
                 else if (args[i].Equals("/debug"))
                 {
                     Utility.debugMode = true;
+                    Utility.SetSmvVar("debugMode", "true");
                     i++;
                 }
                 else if (args[i].StartsWith("/sessionID:", StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
This is a fairly hefty change designed to work with the upcoming release of SDV.

The two major changes are:

- slamcl_writer is now called on each rawcfgf file.  This is in line with the assumptions of the current ESP plugin and required to avoid bugs.
- Significantly more debug output is produced by SmvInterceptorWrapper (and to a lesser extent SmvInterceptor).  This debug output is toggled by the /debug flag and an associated change in SMV-SDV that maps that flag to the SMV_DEBUG_MODE environment variable.  SmvInterceptor's existing debug output is now triggered by this flag/variable _or_ by the existing debug_spew setting in the XML.