### PR TITLE
Fix issue where library processing crashes

### DIFF
--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.IO;
 using System.Globalization;
-using System.Runtime.Remoting.Metadata.W3cXsd2001;
 
 namespace SmvInterceptorWrapper
 {

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -193,6 +193,7 @@ namespace SmvInterceptorWrapper
                         debugTimeout = DEFAULT_DEBUG_TIMEOUT;
                     }
 
+                    // Allow 5 minutes for this, then continue; don't hang indefinitely on debug
                     p.WaitForExit(debugTimeout);
 
                     // Call ESPSMVPRINT_AUX

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -194,7 +194,6 @@ namespace SmvInterceptorWrapper
                         debugTimeout = DEFAULT_DEBUG_TIMEOUT;
                     }
 
-                    // Allow 5 minutes for this, then continue; don't hang indefinitely on debug
                     p.WaitForExit(debugTimeout);
 
                     // Call ESPSMVPRINT_AUX
@@ -220,7 +219,7 @@ namespace SmvInterceptorWrapper
                             File.WriteAllText(cfgErrorPath, p.StandardError.ReadToEnd());
 
                             // Allow 5 minutes for each, then continue; don't hang indefinitely on debug
-                            p.WaitForExit(5 * 60 * 1000);
+                            p.WaitForExit(debugTimeout);
                         }
                     }
                 }
@@ -387,10 +386,12 @@ namespace SmvInterceptorWrapper
 
                             slamLinkProcess = System.Diagnostics.Process.Start(psi);
 
-                            WriteInterceptorLog("EXIT: slamlink.exe.  Exit code: " + slamLinkProcess.ExitCode);
-
                             File.AppendAllText(outDir + "\\smvlink3.log", slamLinkProcess.StandardOutput.ReadToEnd());
                             File.AppendAllText(outDir + "\\smvlink3.log", slamLinkProcess.StandardError.ReadToEnd());
+
+                            slamLinkProcess.WaitForExit();
+
+                            WriteInterceptorLog("EXIT: slamlink.exe.  Exit code: " + slamLinkProcess.ExitCode);
 
                             if (slamLinkProcess.ExitCode != 0) return slamLinkProcess.ExitCode;
                         }


### PR DESCRIPTION
In #30 I added logging to pipe the output of slamlink.exe and its exit code, but forgot to call .WaitForExit() first, which would throw an exception and result in SMV skipping library processing.

This fixes that issue and does two other small cleanups (remove an unneeded using and change a timeout value from raw numbers to the proper const variable.)