### PR TITLE
Update Azure guest OS version to WS2019

### DIFF
--- a/SmvService/ServiceConfiguration.Cloud.cscfg
+++ b/SmvService/ServiceConfiguration.Cloud.cscfg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ServiceConfiguration serviceName="SmvService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="5" osVersion="*" schemaVersion="2015-04.2.6">
+<ServiceConfiguration serviceName="SmvService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="6" osVersion="*" schemaVersion="2015-04.2.6">
   <Role name="SmvCloudWorker">
     <Instances count="1" />
     <ConfigurationSettings>


### PR DESCRIPTION
With our EntityFramework updates, we take a dependency on .NET 4.7.2, which is not supported on WS2016 (Azure guest OS version 5).  The cloud configuration needs to be updated to run correctly.