### PR TITLE
Resolve Code Analysis plugin conflicts in intercepted build.

### DIFF
--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -97,6 +97,17 @@ namespace SmvInterceptorWrapper
                 rspContents = rspContents.Replace("/W1", string.Empty);
                 rspContents = rspContents.Replace("/WX", string.Empty);
 
+                // Remove any CA plugins from the RSP file, as they conflict with CfgPersist.dll
+                Regex codeAnalysisRegex1 = new Regex("/analyze:quiet|/analyze:stacksize\\d+|/analyze:projectdirectory\".*?\"");
+                Regex codeAnalysisRegex2 = new Regex("/analyze:rulesetdirectory\".*?\"|/analyze:ruleset\".*?\"");
+                Regex codeAnalysisRegex3 = new Regex("/analyze:plugin\".*?WindowsPrefast.dll\"|/analyze:plugin\".*?EspXEngine.dll\"|/analyze:plugin\".*?drivers.dll\"");
+                Regex codeAnalysisRegex4 = new Regex("/analyze[^:a-zA-Z0-9]+/"); // This line removes any invalid characters passed to analyze
+
+                rspContents = codeAnalysisRegex1.Replace(rspContents, String.Empty);
+                rspContents = codeAnalysisRegex2.Replace(rspContents, String.Empty);
+                rspContents = codeAnalysisRegex3.Replace(rspContents, String.Empty);
+                rspContents = codeAnalysisRegex4.Replace(rspContents, "/");
+
                 rspFileContent = rspContents;
 
                 string rspContentsDebug = Environment.ExpandEnvironmentVariables(" /nologo /w /Y- /D_PREFAST_ /errorReport:none" + " " + string.Join(" ", iargs)) + " " + rspContents + " /P /Fi.\\sdv\\";

--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -101,7 +101,7 @@ namespace SmvInterceptorWrapper
                 Regex codeAnalysisRegex1 = new Regex("/analyze:quiet|/analyze:stacksize\\d+|/analyze:projectdirectory\".*?\"");
                 Regex codeAnalysisRegex2 = new Regex("/analyze:rulesetdirectory\".*?\"|/analyze:ruleset\".*?\"");
                 Regex codeAnalysisRegex3 = new Regex("/analyze:plugin\".*?WindowsPrefast.dll\"|/analyze:plugin\".*?EspXEngine.dll\"|/analyze:plugin\".*?drivers.dll\"");
-                Regex codeAnalysisRegex4 = new Regex("/analyze[^:a-zA-Z0-9]+/"); // This line removes any invalid characters passed to analyze
+                Regex codeAnalysisRegex4 = new Regex(@"/analyze[^\p{Pd}\w:.]+(\s)*"); // Sometimes, garbage characters are passed to /analyze; this removes them
 
                 rspContents = codeAnalysisRegex1.Replace(rspContents, String.Empty);
                 rspContents = codeAnalysisRegex2.Replace(rspContents, String.Empty);


### PR DESCRIPTION
When projects have Code Analysis enabled, SMV will fail to run due to changes in CfgPersist.dll and the Code Analysis plugins over the years that have resulted in errors when running both plugins at once.

As such, this change updates our logic to remove CA and its associated plugins from our RSP file we use to run our intercepted build.

* Add regex to remove conflicting Code Analysis plugins from RSP.

* Fix unintentional trailing whitespace.