### PR TITLE
Fix support for source filenames with dashes and spaces.

### DIFF
--- a/SmvInterceptorWrapper/Program.cs
+++ b/SmvInterceptorWrapper/Program.cs
@@ -122,10 +122,10 @@ namespace SmvInterceptorWrapper
                 // Persist the RSP file 
                 // Remove file names (*.c) from the content
                 // Ensure we get cases with quotation marks first
-                Regex fileNameRegexQuote1 = new Regex(@"([\s]+("")[\w\p{Pd}\p{Pc}\s]+\.c\b(""))", RegexOptions.IgnoreCase | RegexOptions.Multiline);
-                Regex fileNameRegexQuote2 = new Regex(@"([\s]+("")[\w\p{Pd}\p{Pc}\s]+\.(cpp|cxx)\b(""))", RegexOptions.IgnoreCase | RegexOptions.Multiline);
-                Regex fileNameRegex1 = new Regex(@"([\s]+[\w\p{Pd}\p{Pc}]+\.c\b)", RegexOptions.IgnoreCase|RegexOptions.Multiline);
-                Regex fileNameRegex2 = new Regex(@"([\s]+[\w\p{Pd}\p{Pc}]+\.(cpp|cxx))", RegexOptions.IgnoreCase|RegexOptions.Multiline);
+                Regex fileNameRegexQuote1 = new Regex(@"([\s]+("")[\w\p{Pd}\p{Pc}\s\\.]+\.c\b(""))", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+                Regex fileNameRegexQuote2 = new Regex(@"([\s]+("")[\w\p{Pd}\p{Pc}\s\\.]+\.(cpp|cxx)\b(""))", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+                Regex fileNameRegex1 = new Regex(@"([\s]+[\w\p{Pd}\p{Pc}\\.]+\.c\b)", RegexOptions.IgnoreCase|RegexOptions.Multiline);
+                Regex fileNameRegex2 = new Regex(@"([\s]+[\w\p{Pd}\p{Pc}\\.]+\.(cpp|cxx))", RegexOptions.IgnoreCase|RegexOptions.Multiline);
 
                 List<string> fileNames = new List<string>();
                 int count = 0;


### PR DESCRIPTION
Filenames in VS2022 and other compilers are valid even if they contain dashes or spaces. However, the interceptor does not correctly account for when these filenames are passed on, as they are often wrapped in quotation marks, which breaks our regex for detecting file names.

This change splits our regex logic so that we first look for filenames surrounded by quotes (ex. "hello world.c", "hello-world.c") and then filenames without quotes (helloworld.c). Later, when passing these filenames into the link stages, we make sure to re-apply quotation marks to ensure the interception linker correctly handles them as well.