### PR TITLE
Additional path logic fix.

### DIFF
--- a/SmvLibrary/Utility.cs
+++ b/SmvLibrary/Utility.cs
@@ -1136,6 +1136,7 @@ namespace SmvLibrary
                             if (Directory.Exists(Path.GetDirectoryName(path)))
                             {
                                 Log.LogInfo("Build path found - " + path, logger);
+                                path = Path.GetDirectoryName(path);
                                 return path;
                             }
                         }


### PR DESCRIPTION
The previous fix missed a line that normalized the directory path to be the actual directory and not the full file path, which was causing failures in some cases.